### PR TITLE
cleanup for buster, ansible 2.9, allowing local override of templated…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Role Variables
 None.
 
 
+Role Templates
+-------------
+
+A set of default templates for `cmdline.txt`, `dhclient.conf`, `ntp.conf`,
+`config.txt`, and `gpsd` are provided in the `templates` subdirectory of this role.
+They should work fine for most applications.  Should local conditions dictate, you
+may optionally override them by putting equivalent-named files in
+`{{ inventory_dir }}/templates`.
+
+
 Dependencies
 ------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,11 +30,13 @@
   apt:
     name: ['ntp', 'pps-tools', 'gpsd', 'gpsd-clients']
 
-- name: Tinajalabs NTP-GPS | Remove unneeded packages with apt
-  apt:
-    name: [ 'bluez', 'triggerhappy', 'wpasupplicant', 'avahi-daemon' ]
-    state: absent
-    purge: yes
+# maybe not such a great plan after all
+# 
+#- name: Tinajalabs NTP-GPS | Remove unneeded packages with apt
+#  apt:
+#    name: [ 'bluez', 'triggerhappy', 'wpasupplicant', 'avahi-daemon' ]
+#    state: absent
+#    purge: yes
 
 #
 # -------------------------------------------------- update files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,12 @@
   apt:
     name: ['ntp', 'pps-tools', 'gpsd', 'gpsd-clients']
 
+- name: Tinajalabs NTP-GPS | Remove unneeded packages with apt
+  apt:
+    name: [ 'bluez', 'triggerhappy', 'wpasupplicant', 'avahi-daemon' ]
+    state: absent
+    purge: yes
+
 #
 # -------------------------------------------------- update files
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,6 +74,8 @@
     dest: /etc/default/gpsd
   vars:
     sources:
+      - "{{ inventory_dir }}/host_files/{{ inventory_hostname }}/gpsd"
+      - "{{ inventory_dir }}/host_files/{{ inventory_hostname }}/gpsd.j2"
       - "{{ inventory_dir }}/templates/gpsd.j2"
       - "{{ role_path }}/templates/gpsd.j2"
 #
@@ -83,6 +85,8 @@
     dest: /etc/ntp.conf
   vars:
     sources:
+      - "{{ inventory_dir }}/host_files/{{ inventory_hostname }}/ntp.conf"
+      - "{{ inventory_dir }}/host_files/{{ inventory_hostname }}/ntp.conf.j2"
       - "{{ inventory_dir }}/templates/ntp.conf.j2"
       - "{{ role_path }}/templates/ntp.conf.j2"
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for tinaja.ntp-gps
 #
+- name: Tinajalabs NTP-GPS | Check to see if running under supported Raspbian release
+  fail:
+    msg: not running on Buster or Stretch.
+  when: ( ansible_distribution_release != "stretch" and ansible_distribution_release != "buster" )
+
 # -------------------------------------------------- disable and stop services
 #
 - name: Tinajalabs NTP-GPS | Make sure hciuart is disabled and stopped
@@ -15,49 +20,63 @@
     enabled: false
     state: stopped
 #
-# -------------------------------------------------- install these packages
+# -------------------------------------------------- update apt and install these packages
 #
+- name: Tinajalabs NTP-GPS | Updating apt cache
+  apt:
+    update_cache: yes
+
 - name: Tinajalabs NTP-GPS | Install packages with apt
   apt:
-    name: "{{ item }}"
-    update_cache: yes
-  with_items:
-    - ntp
-    - pps-tools
-    - gpsd
-    - gpsd-clients
+    name: ['ntp', 'pps-tools', 'gpsd', 'gpsd-clients']
+
 #
 # -------------------------------------------------- update files
 #
 - name: Tinajalabs NTP-GPS | Update /boot/cmdline.txt
   template:
-    src: templates/cmdline.txt.j2
+    src: "{{ lookup('first_found', sources) }}"
     dest: /boot/cmdline.txt
-  when: ansible_distribution_release == "stretch"
+  vars:
+    sources:
+      - "{{ inventory_dir }}/templates/cmdline.txt.j2"
+      - "{{ role_path }}/templates/cmdline.txt.j2"
 #
 - name: Tinajalabs NTP-GPS | Update /boot/config.txt
   template:
-    src: templates/config.txt.j2
+    src: "{{ lookup('first_found', sources) }}"
     dest: /boot/config.txt
-  when: ansible_distribution_release == "stretch"
+  vars:
+    sources:
+      - "{{ inventory_dir }}/templates/config.txt.j2"
+      - "{{ role_path }}/templates/config.txt.j2"
 #
 - name: Tinajalabs NTP-GPS | Update /etc/dhcp/dhclient.conf
   template:
-    src: templates/dhclient.conf.j2
+    src: "{{ lookup('first_found', sources) }}"
     dest: /etc/dhcp/dhclient.conf
-  when: ansible_distribution_release == "stretch"
+  vars:
+    sources:
+      - "{{ inventory_dir }}/templates/dhclient.conf.j2"
+      - "{{ role_path }}/templates/dhclient.conf.j2"
 #
 - name: Tinajalabs NTP-GPS | Update /etc/default/gpsd
   template:
-    src: templates/gpsd.j2
+    src: "{{ lookup('first_found', sources) }}"
     dest: /etc/default/gpsd
-  when: ansible_distribution_release == "stretch"
+  vars:
+    sources:
+      - "{{ inventory_dir }}/templates/gpsd.j2"
+      - "{{ role_path }}/templates/gpsd.j2"
 #
 - name: Tinajalabs NTP-GPS | Update /etc/ntp.conf
   template:
-    src: templates/ntp.conf.j2
+    src: "{{ lookup('first_found', sources) }}"
     dest: /etc/ntp.conf
-  when: ansible_distribution_release == "stretch"
+  vars:
+    sources:
+      - "{{ inventory_dir }}/templates/ntp.conf.j2"
+      - "{{ role_path }}/templates/ntp.conf.j2"
 #
 # -------------------------------------------------- delete files
 #
@@ -69,6 +88,24 @@
     - /etc/dhcp/dhclient-exit-hooks.d/ntp
     - /lib/dhcpcd/dhcpcd-hooks/50-ntp.conf
     - /var/lib/ntp/ntp.conf.dhcp
+#
+# -------------------------------------------------- log files and directories happy
+#
+- name: Tinajalabs NTP-GPS - /var/lib/ntp/ exists and is in good shape
+  file:
+    path: /var/lib/ntp
+    state: directory
+    owner: ntp
+    group: ntp
+    mode: 0755
+#
+- name: Tinajalabs NTP-GPS - /var/lib/ntp/ntp.drift exists and is in good shape
+  file:
+    path: /var/lib/ntp/ntp.drift
+    state: touch
+    owner: ntp
+    group: ntp
+    mode: 0644
 #
 # -------------------------------------------------- restart services
 #

--- a/templates/cmdline.txt.j2
+++ b/templates/cmdline.txt.j2
@@ -1,5 +1,5 @@
 # /boot/cmdline.txt
 # {{ ansible_managed }}
 
-dwc_otg.lpm_enable=0  console=tty1 root=PARTUUID=08616e16-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
+dwc_otg.lpm_enable=0  console=tty1 root=PARTUUID=08616e16-02 rootfstype=ext4 elevator=deadline fsck.repair=yes nohz=off rootwait
 


### PR DESCRIPTION
… files, ntp.drift

Changes to tasks/main.yml:

1) Instead of iterated "when" throughout, fail early if not running a tested release
(stretch or buster) with a "fail" task at the beginning.  This seems reasonable
behavior; you may or may not agree.  Note well that I only personally did
testing under buster (to wit: 2020-02-13-raspbian-buster-lite.img), though
I don't think I did anything that will break Stretch.

2) Break out apt: update_cache as a separate task.  In my experience this is
good hygiene.

3) Change apt install to take an array instead with_items loop (shuts up deprecation
warning from ansible 2.9.7)

4) Change template file names from being found under {{ role_path }}/templates
to allowing local override by putting equivalent named template files 
under {{ inventory_dir }}/templates
much in the same way as variable precedence works.  If you don't put files under
{{ inventory_dir }}/templates behavior remains unchanged.

Unfortunately it's not built into ansible to look back into inventory_dir from a
role however it is desirable in this case to behave rather in the same way as
variable precedence.  Updated the README.md file.

https://docs.ansible.com/ansible/latest/user_guide/playbook_pathing.html

5) Ensure /var/lib/ntp/ is directory/0755/ntp:ntp and /var/lib/ntp/ntp.drift is file/0644/ntp/ntp
The ntp.drift file will only update after ntpd has been running for long
enough to figure out what the drift of the local clock is (the number in it is parts
per million) and it will remain at 0 length until then...  however it will not get
written at all if the permissions aren't perfectly to ntpd's liking.

Cheers,

-r

